### PR TITLE
Allow cross-area allocation of certificates

### DIFF
--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
@@ -44,9 +44,6 @@ public class AllocatedEventVerifier : IEventVerifier<V1.AllocatedEvent>
             if (!otherCertificate.Period.Equals(certificate.Period))
                 return new VerificationResult.Invalid("Certificates are not in the same period");
 
-            if (otherCertificate.GridArea != certificate.GridArea)
-                return new VerificationResult.Invalid("Certificates are not in the same area");
-
             var consumptionSlice = otherCertificate.GetCertificateSlice(payload.ConsumptionSourceSliceHash);
             if (consumptionSlice is null)
                 return new VerificationResult.Invalid("Consumption slice does not exist");

--- a/src/ProjectOrigin.Electricity.Tests/Production/ProductionAllocatedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Production/ProductionAllocatedVerifierTests.cs
@@ -123,7 +123,7 @@ public class ProductionAllocatedVerifierTests
     }
 
     [Fact]
-    public async Task Verifier_AllocateCertificate_InvalidArea()
+    public async Task Verifier_AllocateCertificate_AllowCrossArea()
     {
         var ownerKey = Algorithms.Secp256k1.GenerateNewPrivateKey();
         var (consCert, consParams) = FakeRegister.ConsumptionIssued(ownerKey.PublicKey, 250, area: "DK1");
@@ -135,7 +135,7 @@ public class ProductionAllocatedVerifierTests
 
         var result = await _verifier.Verify(transaction, prodCert, @event);
 
-        result.AssertInvalid("Certificates are not in the same area");
+        result.AssertValid();
     }
 
     [Fact]


### PR DESCRIPTION
This pull request updates the code to allow the claims of certificates across different grid areas. 

Previously, the code only allowed allocation within the same grid area based on feedback #7 and that it is only a requirement when creating fuels for the transport sector.