### PR TITLE
Update period requirements

### DIFF
--- a/src/ProjectOrigin.Electricity.Server/Extensions/IDateIntervalExtensions.cs
+++ b/src/ProjectOrigin.Electricity.Server/Extensions/IDateIntervalExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace ProjectOrigin.Electricity.Extensions;
+
+public static class IDateIntervalExtensions
+{
+    public static TimeSpan GetTimeSpan(this V1.DateInterval dateInterval)
+    {
+        return dateInterval.End.ToDateTimeOffset() - dateInterval.Start.ToDateTimeOffset();
+    }
+
+    public static bool IsDateIntervalOverlapping(this V1.DateInterval first, V1.DateInterval second)
+    {
+        var aStart = first.Start.ToDateTimeOffset();
+        var aEnd = first.End.ToDateTimeOffset();
+        var bStart = second.Start.ToDateTimeOffset();
+        var bEnd = second.End.ToDateTimeOffset();
+
+        return (aStart >= bStart && aEnd <= bEnd) || (bStart >= aStart && bEnd <= aEnd);
+    }
+}

--- a/src/ProjectOrigin.Electricity.Server/Extensions/IDateIntervalExtensions.cs
+++ b/src/ProjectOrigin.Electricity.Server/Extensions/IDateIntervalExtensions.cs
@@ -9,7 +9,7 @@ public static class IDateIntervalExtensions
         return dateInterval.End.ToDateTimeOffset() - dateInterval.Start.ToDateTimeOffset();
     }
 
-    public static bool IsDateIntervalOverlapping(this V1.DateInterval first, V1.DateInterval second)
+    public static bool IsEnclosingOrEnclosed(this V1.DateInterval first, V1.DateInterval second)
     {
         var aStart = first.Start.ToDateTimeOffset();
         var aEnd = first.End.ToDateTimeOffset();

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
@@ -41,8 +41,8 @@ public class AllocatedEventVerifier : IEventVerifier<V1.AllocatedEvent>
             if (otherCertificate.Type != V1.GranularCertificateType.Consumption)
                 return new VerificationResult.Invalid("ConsumptionCertificate is not a consumption certificate");
 
-            if (!otherCertificate.Period.Equals(certificate.Period))
-                return new VerificationResult.Invalid("Certificates are not in the same period");
+            if (!otherCertificate.Period.IsDateIntervalOverlapping(certificate.Period))
+                return new VerificationResult.Invalid("Periods are not overlapping");
 
             var consumptionSlice = otherCertificate.GetCertificateSlice(payload.ConsumptionSourceSliceHash);
             if (consumptionSlice is null)

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
@@ -41,7 +41,7 @@ public class AllocatedEventVerifier : IEventVerifier<V1.AllocatedEvent>
             if (otherCertificate.Type != V1.GranularCertificateType.Consumption)
                 return new VerificationResult.Invalid("ConsumptionCertificate is not a consumption certificate");
 
-            if (!otherCertificate.Period.IsDateIntervalOverlapping(certificate.Period))
+            if (!otherCertificate.Period.IsEnclosingOrEnclosed(certificate.Period))
                 return new VerificationResult.Invalid("Periods are not overlapping");
 
             var consumptionSlice = otherCertificate.GetCertificateSlice(payload.ConsumptionSourceSliceHash);

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
@@ -3,6 +3,7 @@ using ProjectOrigin.Registry.V1;
 using System.Threading.Tasks;
 using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
+using System;
 
 namespace ProjectOrigin.Electricity.Server.Verifiers;
 
@@ -28,6 +29,9 @@ public class IssuedEventVerifier : IEventVerifier<V1.IssuedEvent>
 
         if (!payload.OwnerPublicKey.TryToModel(out _))
             return new VerificationResult.Invalid("Invalid owner key, not a valid publicKey");
+
+        if (payload.Period.GetTimeSpan() > TimeSpan.FromHours(1))
+            return new VerificationResult.Invalid("Invalid period, maximum period is 1 hour");
 
         var areaPublicKey = _gridAreaIssuerService.GetAreaPublicKey(payload.GridArea);
         if (areaPublicKey is null)

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
@@ -33,6 +33,9 @@ public class IssuedEventVerifier : IEventVerifier<V1.IssuedEvent>
         if (payload.Period.GetTimeSpan() > TimeSpan.FromHours(1))
             return new VerificationResult.Invalid("Invalid period, maximum period is 1 hour");
 
+        if (payload.Period.GetTimeSpan() < TimeSpan.FromMinutes(1))
+            return new VerificationResult.Invalid("Invalid period, minimum period is 1 minute");
+
         var areaPublicKey = _gridAreaIssuerService.GetAreaPublicKey(payload.GridArea);
         if (areaPublicKey is null)
             return new VerificationResult.Invalid($"No issuer found for GridArea ”{payload.GridArea}”");

--- a/src/ProjectOrigin.Electricity.Tests/Production/ProductionAllocatedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Production/ProductionAllocatedVerifierTests.cs
@@ -108,7 +108,7 @@ public class ProductionAllocatedVerifierTests
     }
 
     [Fact]
-    public async Task Verifier_AllocateCertificate_ValidPeriod_StartSame_EndDiff()
+    public async Task Verifier_AllocateCertificate_ValidPeriod_EnclosingStart()
     {
         var ownerKey = Algorithms.Secp256k1.GenerateNewPrivateKey();
 
@@ -133,7 +133,7 @@ public class ProductionAllocatedVerifierTests
     }
 
     [Fact]
-    public async Task Verifier_AllocateCertificate_ValidPeriod_StartDiff_EndSame()
+    public async Task Verifier_AllocateCertificate_ValidPeriod_EnclosingEnd()
     {
         var ownerKey = Algorithms.Secp256k1.GenerateNewPrivateKey();
 
@@ -145,7 +145,7 @@ public class ProductionAllocatedVerifierTests
         var (prodCert, prodParams) = FakeRegister.ProductionIssued(ownerKey.PublicKey, 250, periodOverride: new V1.DateInterval()
         {
             Start = Timestamp.FromDateTimeOffset(new DateTimeOffset(2022, 09, 25, 12, 45, 0, TimeSpan.Zero)),
-            End = Timestamp.FromDateTimeOffset(new DateTimeOffset(2022, 09, 25, 13, 00, 0, TimeSpan.Zero))
+            End = Timestamp.FromDateTimeOffset(new DateTimeOffset(2022, 09, 25, 13, 0, 0, TimeSpan.Zero))
         });
         _otherCertificate = consCert;
 
@@ -158,7 +158,7 @@ public class ProductionAllocatedVerifierTests
     }
 
     [Fact]
-    public async Task Verifier_AllocateCertificate_ValidPeriod_Within()
+    public async Task Verifier_AllocateCertificate_ValidPeriod_EnclosingWithin()
     {
         var ownerKey = Algorithms.Secp256k1.GenerateNewPrivateKey();
 
@@ -209,7 +209,7 @@ public class ProductionAllocatedVerifierTests
     }
 
     [Fact]
-    public async Task Verifier_AllocateCertificate_InvalidPeriod_NotWithin_Before()
+    public async Task Verifier_AllocateCertificate_InvalidPeriod_Before()
     {
         var ownerKey = Algorithms.Secp256k1.GenerateNewPrivateKey();
 
@@ -235,7 +235,7 @@ public class ProductionAllocatedVerifierTests
     }
 
     [Fact]
-    public async Task Verifier_AllocateCertificate_InvalidPeriod_NotWithin_After()
+    public async Task Verifier_AllocateCertificate_InvalidPeriod_After()
     {
         var ownerKey = Algorithms.Secp256k1.GenerateNewPrivateKey();
 

--- a/src/ProjectOrigin.Registry.IntegrationTests/MyTest.cs
+++ b/src/ProjectOrigin.Registry.IntegrationTests/MyTest.cs
@@ -1,0 +1,31 @@
+using Xunit;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using Microsoft.Extensions.Logging;
+
+namespace ProjectOrigin.Electricity.IntegrationTests;
+
+public class ContainerTest
+{
+    private const string DockerfilePath = "ProjectOrigin.Registry.Server/Dockerfile";
+
+    [Fact]
+    public async Task TestLatencyParallel()
+    {
+
+        TestcontainersSettings.Logger = LoggerFactory.Create(x =>
+            {
+                x.AddConsole();
+                x.SetMinimumLevel(LogLevel.Debug);
+            }).CreateLogger<ContainerTest>();
+
+        var image = new ImageFromDockerfileBuilder()
+            .WithDockerfileDirectory(CommonDirectoryPath.GetSolutionDirectory(), string.Empty)
+            .WithDockerfile(DockerfilePath)
+            .WithBuildArgument("BUILDPLATFORM", "linux/arm64")
+            .Build();
+
+        await image.CreateAsync().ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
This pull request adds the following:
- Max GC size of 1 hour certificates.
- Allows of claims on period enclosing GCs. 
   From the perspective of the largest period of the two GCs, the smaller must be inside the other, look at the chart below, HasInside options are allowed.

![](https://i.stack.imgur.com/mjQbx.png)
