### PR TITLE
Add TimeConstraint option to NetworkOptions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-    "dotnet-test-explorer.testProjectPath": "src/*.Tests/*.csproj", // filter for .Test to not find Integration tests
+    "dotnet-test-explorer.testProjectPath": "test/*.Tests/*.csproj", // filter for .Test to not find Integration tests
     "dotnet-test-explorer.testArguments": "--collect:\"XPlat Code Coverage\"",
     "coverage-gutters.coverageFileNames": [
         "coverage.cobertura.xml"
     ],
-    "dotnet.defaultSolution": "src/Electricity.sln"
+    "dotnet.defaultSolution": "Electricity.sln"
 }

--- a/src/ProjectOrigin.Electricity/Options/NetworkOptions.cs
+++ b/src/ProjectOrigin.Electricity/Options/NetworkOptions.cs
@@ -1,5 +1,5 @@
 using System.Collections.Generic;
-
+using System.Text.Json.Serialization;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 
 namespace ProjectOrigin.Electricity.Options;
@@ -9,6 +9,14 @@ public record NetworkOptions
     public IDictionary<string, RegistryInfo> Registries { get; init; } = new Dictionary<string, RegistryInfo>();
     public IDictionary<string, AreaInfo> Areas { get; init; } = new Dictionary<string, AreaInfo>();
     public int? DaysBeforeCertificatesExpire { get; init; }
+    public TimeConstraint TimeConstraint { get; init; } = TimeConstraint.Enclosing;
+}
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum TimeConstraint
+{
+    Enclosing,
+    Disabled,
 }
 
 public record RegistryInfo

--- a/test/ProjectOrigin.Electricity.Example/ProjectOrigin.Electricity.Example.csproj
+++ b/test/ProjectOrigin.Electricity.Example/ProjectOrigin.Electricity.Example.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.30.1" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.70.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
     <Protobuf Include="..\..\protos\common.proto" GrpcServices="None" />
     <Protobuf Include="..\..\protos\electricity.proto" GrpcServices="None" />
     <Protobuf Include="..\..\protos\registry.proto" GrpcServices="Client" />

--- a/test/ProjectOrigin.Electricity.Example/ProjectOrigin.Electricity.Example.csproj
+++ b/test/ProjectOrigin.Electricity.Example/ProjectOrigin.Electricity.Example.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Google.Protobuf" Version="3.30.1" />
     <PackageReference Include="Grpc.Tools" Version="2.71.0" />
     <PackageReference Include="Grpc.Net.Client" Version="2.70.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.6.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.7.0" />
     <Protobuf Include="..\..\protos\common.proto" GrpcServices="None" />
     <Protobuf Include="..\..\protos\electricity.proto" GrpcServices="None" />
     <Protobuf Include="..\..\protos\registry.proto" GrpcServices="Client" />

--- a/test/ProjectOrigin.Electricity.IntegrationTests/ContainerTest.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/ContainerTest.cs
@@ -12,7 +12,8 @@ using Docker.DotNet;
 
 namespace ProjectOrigin.Electricity.IntegrationTests;
 
-public class ContainerTest : AbstractFlowTest, IClassFixture<VerifierImageFixture>, IAsyncLifetime
+[Collection("VerifierImageCollection")]
+public class ContainerTest : AbstractFlowTest, IAsyncLifetime
 {
     private const string DockerfilePath = "Electricity.Dockerfile";
     private const int GrpcPort = 5000;
@@ -35,7 +36,7 @@ public class ContainerTest : AbstractFlowTest, IClassFixture<VerifierImageFixtur
         """, ".yaml");
 
         _container = new ContainerBuilder()
-                .WithImage(verifierImageFixture.VerifierImage)
+                .WithImage(verifierImageFixture.Image)
                 .WithPortBinding(GrpcPort, true)
                 .WithResourceMapping(configFile, $"/app/tmp/")
                 .WithEnvironment("Network__ConfigurationUri", $"file:///app/tmp/{Path.GetFileName(configFile)}")

--- a/test/ProjectOrigin.Electricity.IntegrationTests/ContainerTest.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/ContainerTest.cs
@@ -7,37 +7,22 @@ using System.Text;
 using Grpc.Net.Client;
 using ProjectOrigin.TestCommon;
 using System.IO;
-using DotNet.Testcontainers.Images;
 using Xunit.Abstractions;
 using Docker.DotNet;
 
 namespace ProjectOrigin.Electricity.IntegrationTests;
 
-public class ContainerTest : AbstractFlowTest, IAsyncLifetime
+public class ContainerTest : AbstractFlowTest, IClassFixture<VerifierImageFixture>, IAsyncLifetime
 {
     private const string DockerfilePath = "Electricity.Dockerfile";
     private const int GrpcPort = 5000;
 
     private readonly ITestOutputHelper _outputHelper;
-    private readonly IFutureDockerImage _image;
     private readonly IContainer _container;
-    private readonly ModifiedDockerfile _modifiedDockerfile;
 
-    public ContainerTest(ITestOutputHelper outputHelper)
+    public ContainerTest(ITestOutputHelper outputHelper, VerifierImageFixture verifierImageFixture)
     {
         _outputHelper = outputHelper;
-        var solutionDirectory = CommonDirectoryPath.GetSolutionDirectory().DirectoryPath;
-
-        // Testcontainers doesn't support some functionality in Dockerfiles
-        _modifiedDockerfile = new ModifiedDockerfile(Path.Combine(solutionDirectory, DockerfilePath), content => content
-            .Replace(" --platform=$BUILDPLATFORM", "") // not supported by Testcontainers
-            .Replace("-jammy-chiseled-extra", "")); // not supported by Testcontainers because of user permissions
-
-        _image = new ImageFromDockerfileBuilder()
-            .WithDockerfileDirectory(solutionDirectory)
-            .WithDockerfile(_modifiedDockerfile.FileName)
-            .WithLogger(new CustomActionLogger("ImageBuilder", outputHelper.WriteLine))
-            .Build();
 
         var configFile = TempFile.WriteAllText($"""
         registries:
@@ -50,7 +35,7 @@ public class ContainerTest : AbstractFlowTest, IAsyncLifetime
         """, ".yaml");
 
         _container = new ContainerBuilder()
-                .WithImage(_image)
+                .WithImage(verifierImageFixture.VerifierImage)
                 .WithPortBinding(GrpcPort, true)
                 .WithResourceMapping(configFile, $"/app/tmp/")
                 .WithEnvironment("Network__ConfigurationUri", $"file:///app/tmp/{Path.GetFileName(configFile)}")
@@ -67,7 +52,6 @@ public class ContainerTest : AbstractFlowTest, IAsyncLifetime
     {
         try
         {
-            await _image.CreateAsync();
             await _container.StartAsync();
         }
         catch (DockerApiException)
@@ -81,7 +65,6 @@ public class ContainerTest : AbstractFlowTest, IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        _modifiedDockerfile.Dispose();
         await _container.StopAsync();
     }
 

--- a/test/ProjectOrigin.Electricity.IntegrationTests/MisconfigurationTest.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/MisconfigurationTest.cs
@@ -26,8 +26,10 @@ public class MisconfigurationTest
         _serviceFixture = new TestServerFixture<Startup>();
     }
 
-    [Fact]
-    public void ValidYaml()
+    [Theory]
+    [InlineData("Disabled")]
+    [InlineData("Enclosing")]
+    public void ValidYaml(string timeConstraint)
     {
         var issuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
 
@@ -39,6 +41,7 @@ public class MisconfigurationTest
           {Area}:
             issuerKeys:
               - publicKey: {Convert.ToBase64String(Encoding.UTF8.GetBytes(issuerKey.PublicKey.ExportPkixText()))}
+        timeConstraint: {timeConstraint}
         """);
 
         var channel = _serviceFixture.Channel;
@@ -46,8 +49,10 @@ public class MisconfigurationTest
         Assert.NotNull(channel);
     }
 
-    [Fact]
-    public void ValidJson()
+    [Theory]
+    [InlineData("Disabled")]
+    [InlineData("Enclosing")]
+    public void ValidJson(string timeConstraint)
     {
         var issuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
 
@@ -66,15 +71,15 @@ public class MisconfigurationTest
                         }}
                     ]
                 }}
-            }}
-        }}", Area, Convert.ToBase64String(Encoding.UTF8.GetBytes(issuerKey.PublicKey.ExportPkixText()))), ".json");
+            }},
+            ""TimeConstraint"": ""{2}""
+
+        }}", Area, Convert.ToBase64String(Encoding.UTF8.GetBytes(issuerKey.PublicKey.ExportPkixText())), timeConstraint), ".json");
 
         var channel = _serviceFixture.Channel;
 
         Assert.NotNull(channel);
     }
-
-
 
     [Fact]
     public void OptionsValidationException_IfInvalidKeyFormat()
@@ -138,6 +143,27 @@ public class MisconfigurationTest
         var ex = Assert.Throws<OptionsValidationException>(() => { var channel = _serviceFixture.Channel; });
         Assert.Equal("Invalid URL address specified for registry ”MyRegistry”", ex.Message);
     }
+
+    [Fact]
+    public void OptionsValidationException_InvalidTimeConstraint()
+    {
+        var issuerKey = Algorithms.Ed25519.GenerateNewPrivateKey();
+
+        ConfigureNetwork($"""
+        registries:
+          MyRegistry:
+            url: https://example.com
+        areas:
+          {Area}:
+            issuerKeys:
+              - publicKey: {Convert.ToBase64String(Encoding.UTF8.GetBytes(issuerKey.PublicKey.ExportPkixText()))}
+        timeConstraint: Invalid
+        """);
+
+        var ex = Assert.Throws<YamlException>(() => { var channel = _serviceFixture.Channel; });
+        Assert.Equal("Requested value 'Invalid' was not found.", ex.InnerException?.Message);
+    }
+
 
     [Fact]
     public void DependencyInjection_Services_ThatVerifiersAreAdded()

--- a/test/ProjectOrigin.Electricity.IntegrationTests/MisconfigurationTest.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/MisconfigurationTest.cs
@@ -177,6 +177,8 @@ public class MisconfigurationTest
         _serviceFixture.GetRequiredService<IEventVerifier<TransferredEvent>>();
         _serviceFixture.GetRequiredService<IEventVerifier<WithdrawnEvent>>();
         _serviceFixture.GetRequiredService<IEventVerifier<UnclaimedEvent>>();
+
+        Assert.True(true);
     }
 
     private void ConfigureValidNetwork()

--- a/test/ProjectOrigin.Electricity.IntegrationTests/UnclaimFlowTest.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/UnclaimFlowTest.cs
@@ -12,6 +12,7 @@ using static ProjectOrigin.Registry.V1.RegistryService;
 
 namespace ProjectOrigin.Electricity.IntegrationTests;
 
+[Collection("VerifierImageCollection")]
 public class UnclaimFlowTest : IClassFixture<RegistryFixture>
 {
     private readonly RegistryServiceClient _registryClient;
@@ -19,7 +20,7 @@ public class UnclaimFlowTest : IClassFixture<RegistryFixture>
     private readonly IPrivateKey _issuerPrivateKeyDk1;
     private readonly IHDPrivateKey _ownerPrivateKey;
 
-    public UnclaimFlowTest(RegistryFixture registryFixture)
+    public UnclaimFlowTest(RegistryFixture registryFixture, VerifierImageFixture verifierImageFixture)
     {
         _registryClient = new RegistryServiceClient(registryFixture.RegistryChannel);
         _registryName = registryFixture.RegistryName;

--- a/test/ProjectOrigin.Electricity.IntegrationTests/VerifierImageFixture.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/VerifierImageFixture.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace ProjectOrigin.Electricity.IntegrationTests;
 
 [CollectionDefinition("VerifierImageCollection")]
-public class AssemblyCollection : ICollectionFixture<VerifierImageFixture>
+public class VerifierImageCollection : ICollectionFixture<VerifierImageFixture>
 {
     // This class is just a marker to associate the fixture with the collection, to only create the image once
 }

--- a/test/ProjectOrigin.Electricity.IntegrationTests/VerifierImageFixture.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/VerifierImageFixture.cs
@@ -1,4 +1,3 @@
-
 using System.IO;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
@@ -7,12 +6,18 @@ using Xunit;
 
 namespace ProjectOrigin.Electricity.IntegrationTests;
 
+[CollectionDefinition("VerifierImageCollection")]
+public class AssemblyCollection : ICollectionFixture<VerifierImageFixture>
+{
+    // This class is just a marker to associate the fixture with the collection, to only create the image once
+}
+
 public class VerifierImageFixture : IAsyncLifetime
 {
     private readonly ModifiedDockerfile _modifiedDockerfile;
     private readonly IFutureDockerImage _verifierImage;
 
-    public IFutureDockerImage VerifierImage => _verifierImage;
+    public IFutureDockerImage Image => _verifierImage;
 
     public VerifierImageFixture()
     {

--- a/test/ProjectOrigin.Electricity.IntegrationTests/VerifierImageFixture.cs
+++ b/test/ProjectOrigin.Electricity.IntegrationTests/VerifierImageFixture.cs
@@ -1,0 +1,42 @@
+
+using System.IO;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Images;
+using Xunit;
+
+namespace ProjectOrigin.Electricity.IntegrationTests;
+
+public class VerifierImageFixture : IAsyncLifetime
+{
+    private readonly ModifiedDockerfile _modifiedDockerfile;
+    private readonly IFutureDockerImage _verifierImage;
+
+    public IFutureDockerImage VerifierImage => _verifierImage;
+
+    public VerifierImageFixture()
+    {
+        var solutionDirectory = CommonDirectoryPath.GetSolutionDirectory().DirectoryPath;
+
+        // Testcontainers doesn't support some functionality in Dockerfiles
+        _modifiedDockerfile = new ModifiedDockerfile(Path.Combine(solutionDirectory, "Electricity.Dockerfile"), content => content
+            .Replace(" --platform=$BUILDPLATFORM", "") // not supported by Testcontainers
+            .Replace("-jammy-chiseled-extra", "")); // not supported by Testcontainers because of user permissions
+
+        _verifierImage = new ImageFromDockerfileBuilder()
+            .WithDockerfileDirectory(solutionDirectory)
+            .WithDockerfile(_modifiedDockerfile.FileName)
+            .Build();
+    }
+
+    public virtual async Task InitializeAsync()
+    {
+        await _verifierImage.CreateAsync();
+    }
+
+    public virtual Task DisposeAsync()
+    {
+        _modifiedDockerfile.Dispose();
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Introduce a TimeConstraint option in NetworkOptions to enhance verification logic, while also correcting the path in VSCode settings for test projects.

This can be configured in the NetworkConfig. The verifier defaults to the existing algorithm (Enclosing), 

```yaml
timeConstraint: Enclosing
```
This can now be set to disabled, this allows one to claim any two periods against each other.
```yaml
timeConstraint: Disabled
```

Also fixed flaky test when building the test image for the container. 