### PR TITLE
Add IsTrial attribute rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/Dockerfile.tmp
+**/*.Dockerfile.tmp
 .debug/
 # ignore all sub charts
 charts/*/charts

--- a/src/ProjectOrigin.Electricity/Models/GranularCertificate.cs
+++ b/src/ProjectOrigin.Electricity/Models/GranularCertificate.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using Google.Protobuf;
 
@@ -74,6 +75,11 @@ public class GranularCertificate
     public bool HasAllocation(Common.V1.Uuid allocationId) => _allocationSlices.ContainsKey(allocationId);
     public AllocationSlice? GetAllocation(Common.V1.Uuid allocationId) => _allocationSlices.GetValueOrDefault(allocationId);
     public AllocationSlice? GetClaim(Common.V1.Uuid allocationId) => _claimedSlices.GetValueOrDefault(allocationId);
+
+    public string? GetAttribute(string key)
+    {
+        return _issued.Attributes.SingleOrDefault(x => x.Key == key)?.Value;
+    }
 
     protected CertificateSlice TakeAvailableSlice(ByteString sliceHash)
     {

--- a/src/ProjectOrigin.Electricity/Rules/IsTrial.cs
+++ b/src/ProjectOrigin.Electricity/Rules/IsTrial.cs
@@ -1,0 +1,18 @@
+namespace ProjectOrigin.Electricity.Rules;
+
+public static class IsTrial
+{
+    public static bool Match(string? left, string? right)
+    {
+        if (left == right)
+            return true;
+
+        if (left is null && right == "false"
+            || left == "false" && right is null)
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/ProjectOrigin.Electricity/Rules/IsTrial.cs
+++ b/src/ProjectOrigin.Electricity/Rules/IsTrial.cs
@@ -2,17 +2,8 @@ namespace ProjectOrigin.Electricity.Rules;
 
 public static class IsTrial
 {
-    public static bool Match(string? left, string? right)
-    {
-        if (left == right)
-            return true;
-
-        if (left is null && right == "false"
-            || left == "false" && right is null)
-        {
-            return true;
-        }
-
-        return false;
-    }
+    public static bool Match(string? left, string? right) =>
+        (left == right)
+        || (left is null && right == "false")
+        || (left == "false" && right is null);
 }

--- a/src/ProjectOrigin.Electricity/Verifiers/Allocated.cs
+++ b/src/ProjectOrigin.Electricity/Verifiers/Allocated.cs
@@ -60,6 +60,9 @@ public class AllocatedEventVerifier : IEventVerifier<V1.AllocatedEvent>
         if (otherCertificate.Type != V1.GranularCertificateType.Consumption)
             return new VerificationResult.Invalid("ConsumptionCertificate is not a consumption certificate");
 
+        if (!Rules.IsTrial.Match(certificate.GetAttribute("IsTrial"), otherCertificate.GetAttribute("IsTrial")))
+            return new VerificationResult.Invalid("Certificates are not of the same trial type");
+
         var verificationResult = VerifyTimeConstraint(certificate, otherCertificate);
         if (verificationResult is VerificationResult.Invalid)
             return verificationResult;

--- a/test/ProjectOrigin.Electricity.Tests/FakeRegister.cs
+++ b/test/ProjectOrigin.Electricity.Tests/FakeRegister.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using AutoFixture;
 using Google.Protobuf;
@@ -42,7 +44,7 @@ internal static class FakeRegister
     }
 
 
-    internal static (GranularCertificate certificate, SecretCommitmentInfo parameters) ConsumptionIssued(IPublicKey ownerKey, uint quantity, string area = "DK1", V1.DateInterval? periodOverride = null)
+    internal static (GranularCertificate certificate, SecretCommitmentInfo parameters) ConsumptionIssued(IPublicKey ownerKey, uint quantity, string area = "DK1", V1.DateInterval? periodOverride = null, IDictionary<string, string>? attributes = null)
     {
         var id = CreateFederatedId();
         var quantityCommitmentParameters = new SecretCommitmentInfo(quantity);
@@ -52,7 +54,9 @@ internal static class FakeRegister
                 quantityCommitmentParameters.ToProtoCommitment(id.StreamId.Value),
                 ownerKey.ToProto(),
                 area,
-                periodOverride);
+                periodOverride,
+                attributes?.Select(kv => new V1.Attribute { Key = kv.Key, Value = kv.Value }) ?? Enumerable.Empty<V1.Attribute>()
+                );
 
         var cert = new GranularCertificate(@event);
 
@@ -123,7 +127,8 @@ internal static class FakeRegister
         V1.Commitment? quantityCommitmentOverride = null,
         V1.PublicKey? ownerKeyOverride = null,
         string? gridAreaOverride = null,
-        V1.DateInterval? periodOverride = null
+        V1.DateInterval? periodOverride = null,
+        IEnumerable<V1.Attribute>? attributes = null
         )
     {
         var id = CreateFederatedId();
@@ -140,6 +145,7 @@ internal static class FakeRegister
             AssetIdHash = ByteString.CopyFrom(gsrnHash),
             QuantityCommitment = quantityCommitmentOverride ?? quantityCommmitment,
             OwnerPublicKey = owner,
+            Attributes = { attributes }
         };
     }
 

--- a/test/ProjectOrigin.Electricity.Tests/IsTrialTests.cs
+++ b/test/ProjectOrigin.Electricity.Tests/IsTrialTests.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace ProjectOrigin.Electricity.Tests;
+
+public class IsTrialTests
+{
+    [Theory]
+    [InlineData(null, null, true)]
+    [InlineData("true", "true", true)]
+    [InlineData("false", "false", true)]
+    [InlineData("false", null, true)]
+    [InlineData(null, "false", true)]
+    [InlineData("true", null, false)]
+    [InlineData(null, "true", false)]
+    [InlineData("true", "false", false)]
+    [InlineData("false", "true", false)]
+    public void IsTrialMatch_ReturnsExpected(string? left, string? right, bool expected)
+    {
+        Assert.Equal(expected, Rules.IsTrial.Match(left, right));
+    }
+}


### PR DESCRIPTION
Introduce the IsTrial rule to determine trial status compatibility between certificates. Both certificates has to have the same value to allow allocation and claim.